### PR TITLE
Display at least two digits in short duration strings

### DIFF
--- a/library/src/commonMain/kotlin/dev/toastbits/ytmkt/uistrings/DurationStrings.kt
+++ b/library/src/commonMain/kotlin/dev/toastbits/ytmkt/uistrings/DurationStrings.kt
@@ -5,6 +5,13 @@ import dev.toastbits.ytmkt.uistrings.localised.getHoursMinutesSecondsSuffixes
 
 private const val HOUR_MS: Long = 3600000L
 
+private fun StringBuilder.appendTwoDigits(n: Long) {
+    if (n < 10) {
+        this.append("0")
+    }
+    this.append("$n")
+}
+
 fun durationToString(duration_ms: Long, hl: String, short: Boolean = false): String {
     val string: StringBuilder = StringBuilder()
 
@@ -14,10 +21,16 @@ fun durationToString(duration_ms: Long, hl: String, short: Boolean = false): Str
 
     if (short) {
         if (hours > 0L) {
-            string.append("$hours:$minutes:$seconds")
+            string.append("$hours")
+            string.append(":")
+            string.appendTwoDigits(minutes)
+            string.append(":")
+            string.appendTwoDigits(seconds)
         }
         else {
-            string.append("$minutes:$seconds")
+            string.append("$minutes")
+            string.append(":")
+            string.appendTwoDigits(seconds)
         }
     }
     else {


### PR DESCRIPTION
In spmp, the durations shown for items in playlists could sometimes contain 1 digit before a colon, like "3:4" for 3 minutes and 4 seconds, which looks a bit jarring. This fix should now show "3:04" instead